### PR TITLE
fix: don't throw client access error for env vars with empty string value

### DIFF
--- a/.changeset/sweet-geese-lick.md
+++ b/.changeset/sweet-geese-lick.md
@@ -1,0 +1,5 @@
+---
+"@acdh-oeaw/validate-env": patch
+---
+
+don't throw client access error for env vars with empty string value

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -311,6 +311,7 @@ test("should display error when server-only variables are accessed on client", (
 			AUTH_URL: "http://localhost:3000/api/auth",
 			NEXT_PUBLIC_APP_BASE_URL: "http://localhost:3000",
 			NEXT_PUBLIC_BOTS: undefined,
+			NEXT_PUBLIC_SEARCH_API_KEY: "",
 			NODE_ENV: "production",
 		},
 		prefix: "NEXT_PUBLIC_",
@@ -332,6 +333,7 @@ test("should display error when server-only variables are accessed on client", (
 				const Schema = v.object({
 					NEXT_PUBLIC_APP_BASE_URL: v.pipe(v.string(), v.url()),
 					NEXT_PUBLIC_BOTS: v.optional(v.picklist(["disabled", "enabled"]), "disabled"),
+					NEXT_PUBLIC_SEARCH_API_KEY: v.optional(v.pipe(v.string(), v.nonEmpty())),
 				});
 
 				const result = v.safeParse(Schema, environment);
@@ -360,6 +362,8 @@ test("should display error when server-only variables are accessed on client", (
 
 	assert.is(env.error, null);
 	assert.not.throws(() => env.value!.NEXT_PUBLIC_APP_BASE_URL);
+	assert.not.throws(() => env.value!.NEXT_PUBLIC_BOTS);
+	assert.not.throws(() => env.value!.NEXT_PUBLIC_SEARCH_API_KEY);
 	assert.throws(() => env.value!.AUTH_URL, /Invalid property access: AUTH_URL./);
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,8 +92,7 @@ export function createEnv<
 > {
 	for (const [key, value] of Object.entries(environment)) {
 		if (value === "") {
-			// eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-			delete environment[key as keyof typeof environment];
+			environment[key as keyof typeof environment] = undefined;
 		}
 	}
 


### PR DESCRIPTION
we should not throw an `InvalidPropertyAccessError` when trying to access an optional env var with an empty string value.

example:

```
# .env.local
NEXT_PUBLIC_SOMETHING_OPTIONAL=
```

previously `NEXT_PUBLIC_SOMETHING` was deleted from `environment` because its value was an empty string, thus throwing `InvalidPropertyAccessError` when being accesed client-side.

we should treat empty string and undefined the same - which should fix this. added a test as well.